### PR TITLE
Fix compile file pattern to only process CoffeeFormation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install -g coffeeformation
 
 There are a couple subcommands:
 
-* `coffeeform compile` evaluates the Coffeeformation files (`*.coffee`) in the current directory
+* `coffeeform compile` evaluates the Coffeeformation files (`*.cf.coffee`) in the current directory
   and generates matching CloudFormation JSON output files.
   This is the default mode, so there's a shorthand: simply `coffeeform`.
 * `coffeeform decompile` is the opposite:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coffeeformation",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -190,12 +190,7 @@ exports.processFile = (file) ->
 
 exports.processFolder = (folder='.') ->
   files = fs.readdirSync folder
-    .filter (name) ->
-      # ignore underscore prefix
-      name[0] isnt '_'
-    .filter (name) ->
-      # implements endsWith
-      name.slice(-exports.extension.length) is exports.extension
+    .filter (name) -> name.match /^(?!_).*\.cf\.coffee$/
     .map exports.processFile
 
   if errors = files.filter((f) -> not f).length


### PR DESCRIPTION
Fix compile file pattern to strictly compile CoffeeFormation files - those ending in .cf.coffee - and update Readme to reflect that.

It would be great to add some tests in the future...