### PR TITLE
Support KMS key and alias resource types

### DIFF
--- a/src/common.coffee
+++ b/src/common.coffee
@@ -40,6 +40,9 @@ exports.ResourceTypes =
 
   kinesisStream: 'AWS::Kinesis::Stream'
 
+  kmsKey: 'AWS::KMS::Key'
+  kmsAlias: 'AWS::KMS::Alias'
+
   elasticIp:       'AWS::EC2::EIP'
   instance:        'AWS::EC2::Instance'
   internetGateway: 'AWS::EC2::InternetGateway'


### PR DESCRIPTION
Add support for KMS key and alias resource types:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_KMS.html