### PR TITLE
Allows to add a DeletionPolicy attribute in each resource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,32 @@
 {
   "name": "coffeeformation",
-  "version": "1.0.12",
-  "lockfileVersion": 1,
+  "version": "1.0.14",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "coffee-script": {
+  "packages": {
+    "": {
+      "name": "coffeeformation",
+      "version": "1.0.14",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "coffee-script": "^1.10.0"
+      },
+      "bin": {
+        "coffeeform": "bin/coffeeform.js"
+      }
+    },
+    "node_modules/coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coffeeformation",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Coffeescript DSL to build AWS CloudFormation templates more easily, with a roundtrip-capable decompiler for your existing JSON templates",
   "bin": {
     "coffeeform": "bin/coffeeform.js"

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -104,7 +104,7 @@ class ResourceBuilder
           props.Tags.push {Key, Value, PropagateAtLaunch}
         delete props.InstanceTags
 
-    for rootKey in ['DependsOn', 'UpdatePolicy']
+    for rootKey in ['DependsOn', 'UpdatePolicy', 'DeletionPolicy']
       if props[rootKey]?
         res[rootKey] = props[rootKey]
         delete props[rootKey]

--- a/src/decompile.coffee
+++ b/src/decompile.coffee
@@ -208,12 +208,12 @@ dumpCondition = (props, puts, depth=2) ->
   puts depth, ')'
 
 dumpResource = (key, props, puts) ->
-  {Type, Condition, DependsOn, UpdatePolicy, Properties} = props
+  {Type, Condition, DependsOn, UpdatePolicy, DeletionPolicy, Properties} = props
   # TODO: warn on others
 
   propCount = if Properties then Object.keys(Properties).length else 0
   comma = ''
-  if Condition or propCount or DependsOn or UpdatePolicy
+  if Condition or propCount or DependsOn or UpdatePolicy or DeletionPolicy
     comma = ','
 
   type = ResourceTypes[Type]
@@ -226,6 +226,7 @@ dumpResource = (key, props, puts) ->
   dumpObject Properties, puts if propCount
   dumpObject {DependsOn}, puts if DependsOn
   dumpObject {UpdatePolicy}, puts if UpdatePolicy
+  dumpObject {DeletionPolicy}, puts if DeletionPolicy
 
 dumpStack = (stack, puts) ->
   puts 0, 'exports.stack = (ref, fn) ->'


### PR DESCRIPTION
Using `DeletionPolicy: Retain` allows us to delete a Cloudformation Stack without deleting the stack resources.

More info: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html